### PR TITLE
Improve board contrast and modernize HUD styling

### DIFF
--- a/src/assets/icons/dropdown-arrow.svg
+++ b/src/assets/icons/dropdown-arrow.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path fill="#0F172A" d="M4.47 6.53a.75.75 0 0 1 1.06 0L8 9l2.47-2.47a.75.75 0 0 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z"/>
+</svg>

--- a/src/assets/icons/dropdown-arrow.svg
+++ b/src/assets/icons/dropdown-arrow.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
-  <path fill="#0F172A" d="M4.47 6.53a.75.75 0 0 1 1.06 0L8 9l2.47-2.47a.75.75 0 0 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z"/>
-</svg>

--- a/src/scripts/ui/renderer.js
+++ b/src/scripts/ui/renderer.js
@@ -15,11 +15,16 @@ function buildTileClassList(tile) {
   const classes = ['tile'];
   if (tile.isRevealed) {
     classes.push('tile--revealed');
+    if (!tile.isMine && tile.adjacentMines === 0) {
+      classes.push('tile--revealed-empty');
+    }
     if (tile.isMine) {
       classes.push('tile--mine');
     } else if (tile.adjacentMines > 0) {
       classes.push(`tile--hint-${tile.adjacentMines}`);
     }
+  } else {
+    classes.push('tile--hidden');
   }
   if (tile.isFlagged) {
     classes.push('tile--flagged');

--- a/src/styles/components/board.css
+++ b/src/styles/components/board.css
@@ -5,11 +5,26 @@
   gap: var(--board-gap);
   justify-content: center;
   padding: var(--space-sm);
-  background: var(--color-surface-alt);
+  background: linear-gradient(155deg, rgba(30, 41, 82, 0.65), rgba(10, 15, 27, 0.92));
+  border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-floating);
+  position: relative;
+  overflow: hidden;
   contain: layout paint;
   content-visibility: auto;
   contain-intrinsic-size: 20rem;
+}
+
+.board::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.18), transparent 68%);
+  pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: 0.85;
 }
 
 .board__row {
@@ -17,21 +32,38 @@
 }
 
 .tile {
+  --tile-bg: linear-gradient(150deg, var(--color-surface-raised) 0%, var(--color-surface) 100%);
+  --tile-border-color: rgba(148, 163, 184, 0.38);
+  --tile-shadow: 0 14px 28px rgba(8, 12, 24, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  --tile-text-color: var(--color-text);
+  --tile-overlay-color: linear-gradient(180deg, rgba(255, 255, 255, 0.16), rgba(15, 23, 42, 0));
+  --tile-overlay-opacity: 0.25;
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  background: linear-gradient(135deg, var(--color-surface) 0%, var(--color-surface-alt, var(--color-surface)) 100%);
-  border: 1px solid rgba(148, 163, 184, 0.4);
+  position: relative;
+  background: var(--tile-bg);
+  border: 1px solid var(--tile-border-color);
   border-radius: calc(var(--radius-sm) * 0.6);
-  box-shadow: 
-    inset 0 1px 0 rgba(255, 255, 255, 0.1),
-    0 1px 3px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--tile-shadow);
   font-weight: 700;
   font-family: var(--font-family-mono);
   font-size: clamp(1rem, 3.1vw, 1.5rem);
-  color: var(--color-text);
+  color: var(--tile-text-color);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: transform var(--transition-fast), box-shadow var(--transition-medium), background var(--transition-medium), border-color var(--transition-fast), color var(--transition-fast), filter var(--transition-fast);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.tile::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--tile-overlay-color);
+  opacity: var(--tile-overlay-opacity);
+  transition: opacity var(--transition-fast);
+  pointer-events: none;
 }
 
 .tile:focus-visible {
@@ -39,46 +71,86 @@
   outline-offset: 2px;
 }
 
-.tile:hover:not(.tile--revealed) {
-  background: linear-gradient(135deg, var(--color-surface-alt, var(--color-surface)) 0%, var(--color-accent-subtle) 100%);
-  border-color: rgba(148, 163, 184, 0.6);
-  box-shadow: 
-    inset 0 1px 0 rgba(255, 255, 255, 0.15),
-    0 2px 6px rgba(0, 0, 0, 0.2);
+.tile--hidden {
+  --tile-bg: linear-gradient(155deg, rgba(33, 51, 90, 0.98), rgba(9, 14, 26, 0.9));
+  --tile-border-color: rgba(148, 163, 184, 0.55);
+  --tile-shadow: 0 18px 34px rgba(7, 12, 24, 0.62), inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  --tile-overlay-opacity: 0.55;
+}
+
+.tile--hidden:hover {
+  transform: translateY(-2px);
+  --tile-overlay-opacity: 0.75;
+  box-shadow: 0 20px 36px rgba(7, 11, 21, 0.66), inset 0 1px 0 rgba(255, 255, 255, 0.22);
+  border-color: rgba(148, 163, 184, 0.7);
+}
+
+.tile--hidden:active {
+  transform: translateY(0);
+  box-shadow: var(--shadow-pressed);
+  --tile-overlay-opacity: 0.4;
 }
 
 .tile--revealed {
-  background: linear-gradient(135deg, rgba(30, 42, 71, 0.95) 0%, rgba(15, 23, 42, 0.9) 100%);
-  border-color: rgba(148, 163, 184, 0.6);
-  box-shadow: 
-    inset 0 1px 3px rgba(0, 0, 0, 0.4),
-    0 0 0 1px rgba(148, 163, 184, 0.1);
+  --tile-bg: linear-gradient(160deg, rgba(69, 83, 122, 0.35), rgba(12, 18, 34, 0.9));
+  --tile-border-color: rgba(148, 163, 184, 0.26);
+  --tile-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), inset 0 -6px 16px rgba(6, 10, 20, 0.66);
+  --tile-overlay-opacity: 0;
+  --tile-text-color: rgba(226, 232, 240, 0.92);
   cursor: default;
-  transform: translateY(1px);
+  transform: none;
+  box-shadow: var(--tile-shadow);
+}
+
+.tile--revealed::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 35% 30%, rgba(56, 189, 248, 0.25), transparent 65%);
+  opacity: 0.4;
+  mix-blend-mode: lighten;
+  pointer-events: none;
+}
+
+.tile--revealed-empty {
+  --tile-bg: linear-gradient(155deg, rgba(56, 189, 248, 0.08), rgba(15, 23, 42, 0.85));
+  --tile-border-color: rgba(148, 163, 184, 0.16);
+  --tile-text-color: rgba(226, 232, 240, 0.7);
 }
 
 .tile--mine {
-  color: var(--color-danger);
+  --tile-overlay-color: radial-gradient(circle, rgba(248, 113, 113, 0.65) 0%, transparent 70%);
+  --tile-overlay-opacity: 1;
+  color: #fca5a5;
+  text-shadow: 0 0 12px rgba(248, 113, 113, 0.6);
 }
 
 .tile--flagged {
-  color: var(--color-warning);
+  --tile-overlay-color: linear-gradient(150deg, rgba(250, 204, 21, 0.32), rgba(56, 189, 248, 0.1));
+  --tile-overlay-opacity: 0.85;
+  color: #fef08a;
+  text-shadow: 0 4px 12px rgba(250, 204, 21, 0.35);
 }
 
 .tile--questioned {
+  --tile-overlay-color: linear-gradient(150deg, rgba(56, 189, 248, 0.3), rgba(148, 163, 184, 0.18));
+  --tile-overlay-opacity: 0.7;
   color: var(--color-accent);
 }
 
 .tile--hint-1 {
-  color: #38bdf8;
+  color: #7dd3fc;
+  text-shadow: 0 0 8px rgba(125, 211, 252, 0.55);
 }
 
 .tile--hint-2 {
-  color: #34d399;
+  color: #4ade80;
+  text-shadow: 0 0 8px rgba(74, 222, 128, 0.4);
 }
 
 .tile--hint-3 {
   color: #f97316;
+  text-shadow: 0 0 6px rgba(249, 115, 22, 0.35);
 }
 
 .tile--hint-4,
@@ -87,6 +159,7 @@
 .tile--hint-7,
 .tile--hint-8 {
   color: #f87171;
+  text-shadow: 0 0 6px rgba(248, 113, 113, 0.45);
 }
 
 @media (max-width: 40rem) {

--- a/src/styles/components/board.css
+++ b/src/styles/components/board.css
@@ -92,30 +92,32 @@
 }
 
 .tile--revealed {
-  --tile-bg: linear-gradient(160deg, rgba(69, 83, 122, 0.35), rgba(12, 18, 34, 0.9));
-  --tile-border-color: var(--color-border-soft);
-  --tile-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), inset 0 -6px 16px rgba(6, 10, 20, 0.66);
-  --tile-overlay-opacity: 0;
-  --tile-text-color: rgba(226, 232, 240, 0.92);
+  --tile-bg: linear-gradient(165deg, rgba(132, 204, 255, 0.45), rgba(28, 46, 86, 0.72));
+  --tile-border-color: var(--color-border-faint);
+  --tile-shadow: inset 0 2px 5px rgba(255, 255, 255, 0.18), inset 0 -8px 16px rgba(12, 20, 40, 0.42);
+  --tile-overlay-color: linear-gradient(180deg, rgba(255, 255, 255, 0.35), rgba(56, 189, 248, 0.18));
+  --tile-overlay-opacity: 0.34;
+  --tile-text-color: rgba(13, 23, 44, 0.88);
   cursor: default;
   transform: none;
-  box-shadow: var(--tile-shadow);
+  box-shadow: var(--tile-shadow), 0 8px 22px rgba(56, 189, 248, 0.22);
 }
 
 .tile--revealed::before {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 35% 30%, rgba(56, 189, 248, 0.25), transparent 65%);
-  opacity: 0.4;
+  background: radial-gradient(circle at 35% 30%, rgba(148, 227, 255, 0.45), transparent 70%);
+  opacity: 0.5;
   mix-blend-mode: lighten;
   pointer-events: none;
 }
 
 .tile--revealed-empty {
-  --tile-bg: linear-gradient(155deg, rgba(56, 189, 248, 0.08), rgba(15, 23, 42, 0.85));
-  --tile-border-color: var(--color-border-faint);
-  --tile-text-color: rgba(226, 232, 240, 0.7);
+  --tile-bg: linear-gradient(160deg, rgba(191, 239, 255, 0.65), rgba(43, 66, 118, 0.55));
+  --tile-border-color: rgba(191, 239, 255, 0.4);
+  --tile-overlay-opacity: 0.38;
+  --tile-text-color: rgba(12, 22, 42, 0.78);
 }
 
 .tile--mine {
@@ -139,18 +141,18 @@
 }
 
 .tile--hint-1 {
-  color: #7dd3fc;
-  text-shadow: 0 0 8px rgba(125, 211, 252, 0.55);
+  color: #021835;
+  text-shadow: none;
 }
 
 .tile--hint-2 {
-  color: #4ade80;
-  text-shadow: 0 0 8px rgba(74, 222, 128, 0.4);
+  color: #06301f;
+  text-shadow: none;
 }
 
 .tile--hint-3 {
-  color: #f97316;
-  text-shadow: 0 0 6px rgba(249, 115, 22, 0.35);
+  color: #5a2200;
+  text-shadow: none;
 }
 
 .tile--hint-4,
@@ -158,8 +160,8 @@
 .tile--hint-6,
 .tile--hint-7,
 .tile--hint-8 {
-  color: #f87171;
-  text-shadow: 0 0 6px rgba(248, 113, 113, 0.45);
+  color: #420606;
+  text-shadow: none;
 }
 
 @media (max-width: 40rem) {

--- a/src/styles/components/board.css
+++ b/src/styles/components/board.css
@@ -6,7 +6,7 @@
   justify-content: center;
   padding: var(--space-sm);
   background: linear-gradient(155deg, rgba(30, 41, 82, 0.65), rgba(10, 15, 27, 0.92));
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-ambient);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-floating);
   position: relative;
@@ -33,10 +33,10 @@
 
 .tile {
   --tile-bg: linear-gradient(150deg, var(--color-surface-raised) 0%, var(--color-surface) 100%);
-  --tile-border-color: rgba(148, 163, 184, 0.38);
-  --tile-shadow: 0 14px 28px rgba(8, 12, 24, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  --tile-border-color: var(--color-border-medium);
+  --tile-shadow: var(--shadow-tile), inset 0 1px 0 rgba(255, 255, 255, 0.12);
   --tile-text-color: var(--color-text);
-  --tile-overlay-color: linear-gradient(180deg, rgba(255, 255, 255, 0.16), rgba(15, 23, 42, 0));
+  --tile-overlay-color: linear-gradient(180deg, var(--color-surface-highlight), rgba(15, 23, 42, 0));
   --tile-overlay-opacity: 0.25;
   display: inline-flex;
   justify-content: center;
@@ -73,16 +73,16 @@
 
 .tile--hidden {
   --tile-bg: linear-gradient(155deg, rgba(33, 51, 90, 0.98), rgba(9, 14, 26, 0.9));
-  --tile-border-color: rgba(148, 163, 184, 0.55);
-  --tile-shadow: 0 18px 34px rgba(7, 12, 24, 0.62), inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  --tile-border-color: var(--color-border-strong);
+  --tile-shadow: var(--shadow-tile-hidden), inset 0 1px 0 rgba(255, 255, 255, 0.18);
   --tile-overlay-opacity: 0.55;
 }
 
 .tile--hidden:hover {
   transform: translateY(-2px);
   --tile-overlay-opacity: 0.75;
-  box-shadow: 0 20px 36px rgba(7, 11, 21, 0.66), inset 0 1px 0 rgba(255, 255, 255, 0.22);
-  border-color: rgba(148, 163, 184, 0.7);
+  box-shadow: var(--shadow-tile-hover), inset 0 1px 0 rgba(255, 255, 255, 0.22);
+  border-color: var(--color-border-emphasis);
 }
 
 .tile--hidden:active {
@@ -93,7 +93,7 @@
 
 .tile--revealed {
   --tile-bg: linear-gradient(160deg, rgba(69, 83, 122, 0.35), rgba(12, 18, 34, 0.9));
-  --tile-border-color: rgba(148, 163, 184, 0.26);
+  --tile-border-color: var(--color-border-soft);
   --tile-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), inset 0 -6px 16px rgba(6, 10, 20, 0.66);
   --tile-overlay-opacity: 0;
   --tile-text-color: rgba(226, 232, 240, 0.92);
@@ -114,7 +114,7 @@
 
 .tile--revealed-empty {
   --tile-bg: linear-gradient(155deg, rgba(56, 189, 248, 0.08), rgba(15, 23, 42, 0.85));
-  --tile-border-color: rgba(148, 163, 184, 0.16);
+  --tile-border-color: var(--color-border-faint);
   --tile-text-color: rgba(226, 232, 240, 0.7);
 }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -22,18 +22,44 @@ body {
 }
 
 main {
+  position: relative;
   width: min(72rem, 100%);
-  background: rgba(15, 23, 42, 0.72);
-  backdrop-filter: blur(18px);
+  background: linear-gradient(160deg, rgba(16, 24, 42, 0.88), rgba(8, 13, 24, 0.92));
+  border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-elevated);
   overflow: hidden;
+  backdrop-filter: blur(18px);
+}
+
+main::before,
+main::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  mix-blend-mode: screen;
+  opacity: 0.55;
+}
+
+main::before {
+  background: radial-gradient(circle at 15% 10%, rgba(56, 189, 248, 0.25), transparent 60%);
+}
+
+main::after {
+  background: radial-gradient(circle at 80% 85%, rgba(60, 130, 246, 0.1), transparent 65%);
 }
 
 .app-shell {
+  position: relative;
   display: grid;
   gap: var(--space-lg);
   padding: var(--space-lg);
+  background: linear-gradient(160deg, rgba(23, 34, 62, 0.78), rgba(11, 19, 36, 0.68));
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: calc(var(--radius-md) - var(--space-xs));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .hud {
@@ -47,37 +73,80 @@ main {
   display: flex;
   gap: var(--space-sm);
   align-items: center;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  padding: var(--space-xs) var(--space-sm);
+  background: linear-gradient(155deg, rgba(19, 30, 55, 0.78), rgba(9, 16, 30, 0.6));
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: calc(var(--radius-sm) * 1.1);
+  box-shadow: 0 12px 30px rgba(8, 12, 24, 0.35);
+  backdrop-filter: blur(10px);
 }
 
 .hud__group--status {
   grid-column: 1 / -1;
-  background: var(--color-surface);
+  background: linear-gradient(160deg, rgba(56, 189, 248, 0.12), rgba(15, 23, 42, 0.85));
+  border: 1px solid rgba(56, 189, 248, 0.24);
   padding: var(--space-sm);
-  border-radius: var(--radius-sm);
+  box-shadow: 0 16px 32px rgba(8, 12, 24, 0.4);
+}
+
+.hud__group--status > [role='status'] {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.hud__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(226, 232, 240, 0.7);
+  flex: 1 1 100%;
 }
 
 .hud__metric {
   font-family: var(--font-family-mono);
   font-size: 1.25rem;
   letter-spacing: 0.08em;
+  padding: 0.35rem 0.85rem;
+  border-radius: calc(var(--radius-sm) * 0.9);
+  background: rgba(8, 13, 24, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 6px 12px rgba(8, 12, 24, 0.25);
 }
 
 .hud__button,
 .hud__select {
-  background: var(--color-accent);
-  border: none;
+  position: relative;
+  background: linear-gradient(145deg, rgba(56, 189, 248, 0.92), rgba(56, 189, 248, 0.75));
+  border: 1px solid rgba(56, 189, 248, 0.55);
   color: #0f172a;
   font-weight: 600;
   padding: var(--space-xs) var(--space-md);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), filter var(--transition-fast);
+  box-shadow: 0 12px 26px rgba(56, 189, 248, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.3);
+}
+
+.hud__select {
+  appearance: none;
+  padding-right: calc(var(--space-md) * 1.6);
+  background-image: linear-gradient(145deg, rgba(56, 189, 248, 0.92), rgba(56, 189, 248, 0.75)),
+    url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"%3E%3Cpath fill="%230f172a" d="M4.47 6.53a.75.75 0 0 1 1.06 0L8 9.0l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z"/%3E%3C/svg%3E');
+  background-repeat: no-repeat, no-repeat;
+  background-position: center, calc(100% - var(--space-sm)) 50%;
+  background-size: 100% 100%, 1rem;
+}
+
+.hud__select::-ms-expand {
+  display: none;
 }
 
 .hud__button:hover,
 .hud__select:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 8px 18px rgba(56, 189, 248, 0.35);
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(56, 189, 248, 0.4);
 }
 
 .hud__button:focus-visible,
@@ -86,9 +155,28 @@ main {
   outline-offset: 2px;
 }
 
+.hud__button:active,
+.hud__select:active {
+  transform: translateY(0);
+  box-shadow: 0 6px 14px rgba(56, 189, 248, 0.35);
+  filter: brightness(0.95);
+}
+
 .layout {
   display: grid;
   gap: var(--space-lg);
+}
+
+@media (min-width: 28rem) {
+  .hud__group {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+  }
+
+  .hud__label {
+    flex: 0;
+    margin-right: var(--space-xs);
+  }
 }
 
 @media (min-width: var(--breakpoint-tablet)) {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -25,7 +25,7 @@ main {
   position: relative;
   width: min(72rem, 100%);
   background: linear-gradient(160deg, rgba(16, 24, 42, 0.88), rgba(8, 13, 24, 0.92));
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-ambient);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-elevated);
   overflow: hidden;
@@ -79,7 +79,7 @@ main::after {
   background: linear-gradient(155deg, rgba(19, 30, 55, 0.78), rgba(9, 16, 30, 0.6));
   border: 1px solid rgba(148, 163, 184, 0.14);
   border-radius: calc(var(--radius-sm) * 1.1);
-  box-shadow: 0 12px 30px rgba(8, 12, 24, 0.35);
+  box-shadow: var(--shadow-card);
   backdrop-filter: blur(10px);
 }
 
@@ -88,7 +88,7 @@ main::after {
   background: linear-gradient(160deg, rgba(56, 189, 248, 0.12), rgba(15, 23, 42, 0.85));
   border: 1px solid rgba(56, 189, 248, 0.24);
   padding: var(--space-sm);
-  box-shadow: 0 16px 32px rgba(8, 12, 24, 0.4);
+  box-shadow: var(--shadow-card-strong);
 }
 
 .hud__group--status > [role='status'] {
@@ -126,14 +126,14 @@ main::after {
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: transform var(--transition-fast), box-shadow var(--transition-fast), filter var(--transition-fast);
-  box-shadow: 0 12px 26px rgba(56, 189, 248, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.3);
+  box-shadow: var(--shadow-button), inset 0 1px 0 rgba(255, 255, 255, 0.3);
 }
 
 .hud__select {
   appearance: none;
   padding-right: calc(var(--space-md) * 1.6);
   background-image: linear-gradient(145deg, rgba(56, 189, 248, 0.92), rgba(56, 189, 248, 0.75)),
-    url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"%3E%3Cpath fill="%230f172a" d="M4.47 6.53a.75.75 0 0 1 1.06 0L8 9.0l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z"/%3E%3C/svg%3E');
+    url('../assets/icons/dropdown-arrow.svg');
   background-repeat: no-repeat, no-repeat;
   background-position: center, calc(100% - var(--space-sm)) 50%;
   background-size: 100% 100%, 1rem;
@@ -146,7 +146,7 @@ main::after {
 .hud__button:hover,
 .hud__select:hover {
   transform: translateY(-2px);
-  box-shadow: 0 16px 32px rgba(56, 189, 248, 0.4);
+  box-shadow: var(--shadow-button-hover);
 }
 
 .hud__button:focus-visible,
@@ -158,7 +158,7 @@ main::after {
 .hud__button:active,
 .hud__select:active {
   transform: translateY(0);
-  box-shadow: 0 6px 14px rgba(56, 189, 248, 0.35);
+  box-shadow: var(--shadow-button-active);
   filter: brightness(0.95);
 }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -133,7 +133,7 @@ main::after {
   appearance: none;
   padding-right: calc(var(--space-md) * 1.6);
   background-image: linear-gradient(145deg, rgba(56, 189, 248, 0.92), rgba(56, 189, 248, 0.75)),
-    url('../assets/icons/dropdown-arrow.svg');
+    var(--icon-dropdown-url);
   background-repeat: no-repeat, no-repeat;
   background-position: center, calc(100% - var(--space-sm)) 50%;
   background-size: 100% 100%, 1rem;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -2,6 +2,9 @@
   --color-background: #0f172a;
   --color-surface: #15203b;
   --color-surface-alt: #1e2a47;
+  --color-surface-raised: #22335a;
+  --color-surface-pressed: #101a33;
+  --color-surface-highlight: rgba(255, 255, 255, 0.12);
   --color-text: #e2e8f0;
   --color-accent: #38bdf8;
   --color-accent-rgb: 56 189 248;
@@ -19,7 +22,10 @@
   --radius-sm: 0.375rem;
   --radius-md: 0.75rem;
   --shadow-elevated: 0 18px 40px rgba(15, 23, 42, 0.45);
+  --shadow-floating: 0 18px 36px rgba(8, 12, 24, 0.55);
+  --shadow-pressed: inset 0 1px 0 rgba(255, 255, 255, 0.08), inset 0 -4px 12px rgba(8, 12, 24, 0.55);
   --transition-fast: 120ms ease;
+  --transition-medium: 180ms ease;
   --transition-slow: 220ms ease;
   --breakpoint-tablet: 48rem;
   --breakpoint-desktop: 64rem;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -5,6 +5,12 @@
   --color-surface-raised: #22335a;
   --color-surface-pressed: #101a33;
   --color-surface-highlight: rgba(255, 255, 255, 0.12);
+  --color-border-strong: rgba(148, 163, 184, 0.55);
+  --color-border-medium: rgba(148, 163, 184, 0.38);
+  --color-border-soft: rgba(148, 163, 184, 0.26);
+  --color-border-faint: rgba(148, 163, 184, 0.16);
+  --color-border-ambient: rgba(148, 163, 184, 0.18);
+  --color-border-emphasis: rgba(148, 163, 184, 0.7);
   --color-text: #e2e8f0;
   --color-accent: #38bdf8;
   --color-accent-rgb: 56 189 248;
@@ -24,6 +30,14 @@
   --shadow-elevated: 0 18px 40px rgba(15, 23, 42, 0.45);
   --shadow-floating: 0 18px 36px rgba(8, 12, 24, 0.55);
   --shadow-pressed: inset 0 1px 0 rgba(255, 255, 255, 0.08), inset 0 -4px 12px rgba(8, 12, 24, 0.55);
+  --shadow-card: 0 12px 30px rgba(8, 12, 24, 0.35);
+  --shadow-card-strong: 0 16px 32px rgba(8, 12, 24, 0.4);
+  --shadow-button: 0 12px 26px rgba(56, 189, 248, 0.35);
+  --shadow-button-hover: 0 16px 32px rgba(56, 189, 248, 0.4);
+  --shadow-button-active: 0 6px 14px rgba(56, 189, 248, 0.35);
+  --shadow-tile: 0 14px 28px rgba(8, 12, 24, 0.55);
+  --shadow-tile-hidden: 0 18px 34px rgba(7, 12, 24, 0.62);
+  --shadow-tile-hover: 0 20px 36px rgba(7, 11, 21, 0.66);
   --transition-fast: 120ms ease;
   --transition-medium: 180ms ease;
   --transition-slow: 220ms ease;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -11,6 +11,7 @@
   --color-border-faint: rgba(148, 163, 184, 0.16);
   --color-border-ambient: rgba(148, 163, 184, 0.18);
   --color-border-emphasis: rgba(148, 163, 184, 0.7);
+  --icon-dropdown-url: url("data:image/svg+xml;utf8,<svg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M4 6L8 10L12 6' stroke='%230f172a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/></svg>");
   --color-text: #e2e8f0;
   --color-accent: #38bdf8;
   --color-accent-rgb: 56 189 248;


### PR DESCRIPTION
## Summary
- add explicit tile classes and refreshed gradients so hidden and revealed states are visually distinct
- layer the board, HUD, and controls with modern glassmorphism-inspired treatments
- extend design tokens with shadows and transitions to support the updated look

## Testing
- npm run test:unit

Resolves #3